### PR TITLE
store configuration as hash with indifferent access

### DIFF
--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 6.0.0"
+  spec.add_dependency "activerecord", ">= 6.0.0"
   spec.add_dependency "tiny_tds"
 end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -31,15 +31,6 @@ module ActiveRecord
           def build_count_subquery(relation, column_name, distinct)
             super(relation.unscope(:order), column_name, distinct)
           end
-
-          def type_cast_calculated_value(value, type, operation = nil)
-            case operation
-            when "count"   then value.to_i
-            when "sum"     then type.deserialize(value || 0)
-            when "average" then value&.respond_to?(:to_d) ? value.to_d : value
-            else type.deserialize(value)
-            end
-          end
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      BASE_SCHEMA_CREATION_CLASS = Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1 ?
+      BASE_SCHEMA_CREATION_CLASS = ((ActiveRecord.version <=> Gem::Version.new("6.1")) != -1) ?
         SchemaCreation :
         AbstractAdapter::SchemaCreation
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -3,7 +3,11 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      BASE_SCHEMA_CREATION_CLASS = Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1 ?
+        SchemaCreation :
+        AbstractAdapter::SchemaCreation
+
+      class SchemaCreation < BASE_SCHEMA_CREATION_CLASS
         private
 
         def visit_TableDefinition(o)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -402,10 +402,12 @@ module ActiveRecord
               else
                 type = case ci[:type]
                        when /smallint|int|bigint/ then ci[:_type]
+                       when /bit/ then 'smallint'
                        else ci[:type]
                        end
                 value = default.match(/\A\((.*)\)\Z/m)[1]
                 value = select_value("SELECT CAST(#{value} AS #{type}) AS value", "SCHEMA")
+
                 [value, nil]
               end
             end

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,10 +31,18 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      def initialize(connection, **args)
-        @connection = connection
-        @starting_isolation_level = current_isolation_level if args[:isolation]
-        super
+      if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
+        def initialize(connection, **args)
+          @connection = connection
+          @starting_isolation_level = current_isolation_level if args[:isolation]
+          super
+        end
+      else
+        def initialize(connection, options, **args)
+          @connection = connection
+          @starting_isolation_level = current_isolation_level if options[:isolation]
+          super
+        end
       end
 
       def commit

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,9 +31,9 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      def initialize(connection, options, **args)
+      def initialize(connection, **args)
         @connection = connection
-        @starting_isolation_level = current_isolation_level if options[:isolation]
+        @starting_isolation_level = current_isolation_level if args[:isolation]
         super
       end
 

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,7 +31,7 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
+      if (ActiveRecord.version <=> Gem::Version.new("6.1")) != -1
         def initialize(connection, **args)
           @connection = connection
           @starting_isolation_level = current_isolation_level if args[:isolation]

--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -14,7 +14,7 @@ module ActiveRecord
                to: ActiveRecord::Base
 
       def initialize(configuration)
-        @configuration = configuration
+        @configuration = ActiveSupport::HashWithIndifferentAccess.new(configuration)
       end
 
       def create(master_established = false)

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -99,7 +99,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "bit"
       _(col.type).must_equal               :boolean
       _(col.null).must_equal               true
-      _(col.default).must_equal            true
+      _(col.default).must_equal            "1"
       _(obj.bit).must_equal                true
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -99,7 +99,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "bit"
       _(col.type).must_equal               :boolean
       _(col.null).must_equal               true
-      _(col.default).must_equal            "1"
+      _(col.default).must_equal            1
       _(obj.bit).must_equal                true
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)


### PR DESCRIPTION
Ran into this while testing your PR - database tasks would fail when trying to access the configuration hash because all of the keys were symbols. 
